### PR TITLE
refactor: :recycle: Centralizar DB_FILE en config.py

### DIFF
--- a/modules/controllers/addController.py
+++ b/modules/controllers/addController.py
@@ -1,9 +1,9 @@
+from modules.utils.config import DB_FILE
 import modules.msg as msg
 import modules.validateData as vd
 import modules.screenController as sc
 import modules.utils.corefiles as cf
 import random
-DB_FILE = "data/dbmain.json"
 
 def addMenu():
     sc.limpiar_pantalla()
@@ -27,7 +27,7 @@ def addMenu():
 
                 }
             }
-            cf.updateJson(DB_FILE, CERVEZA,["Beer"])
+            cf.updateJson(CERVEZA,["Beer"])
             return addMenu()
         case "2":
             sc.limpiar_pantalla()
@@ -46,7 +46,7 @@ def addMenu():
 
                 }
             }
-            cf.updateJson(DB_FILE, VINO,["Vino"])
+            cf.updateJson(VINO,["Vino"])
             return addMenu()
         case "3":
             sc.limpiar_pantalla()
@@ -65,7 +65,7 @@ def addMenu():
 
                 }
             }
-            cf.updateJson(DB_FILE, LICORES,["Liquors"])
+            cf.updateJson(LICORES,["Liquors"])
             return addMenu()
         case "4":
             pass

--- a/modules/utils/config.py
+++ b/modules/utils/config.py
@@ -1,0 +1,1 @@
+DB_FILE = "data/dbmain.json"

--- a/modules/utils/corefiles.py
+++ b/modules/utils/corefiles.py
@@ -1,23 +1,23 @@
 import os 
 import json
 from typing import Dict, List, Optional
+from config import DB_FILE
 
 
-DB_FILE = "data/dbmain.json"
 
 #FUNCION PARA CARGAR LA BASE DE DATOS SE UTILIZA PARA REALIZAR FUNCIONES Y QUE ME RELACIONE LA INFORMACION CON LA BASE DE DATOS
-def readJson(DB_FILE : str)->Dict:
+def readJson()->Dict:
     try:
         with open(DB_FILE, "r", encoding="utf-8") as cf:
             return json.load(cf)
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 #FUNCION PARA QUE ME ESCRIBA Y ME MUESTRE LA BASE DE DATOS ES POSIBLE MODIFICAR QUE ESPACIOS PUEDO IMPRIMIR
-def writeJson(DB_FILE : str, data : Dict)->Dict:
+def writeJson(data : Dict)->Dict:
     with open(DB_FILE, "w", encoding="utf-8") as cf:
         json.dump(data, cf, indent=4)
 #FUNCION QUE SE ENCARGA DE ACTUALIZAR LA BASE DE DATOS CON LOS VALORES QUE YO CONSIDERE
-def updateJson(DB_FILE : str, data : Dict, path: Optional[List[str]] = None) -> None:
+def updateJson(data : Dict, path: Optional[List[str]] = None) -> None:
     currentData = readJson(DB_FILE)
 
     if not path:
@@ -31,7 +31,7 @@ def updateJson(DB_FILE : str, data : Dict, path: Optional[List[str]] = None) -> 
     
     writeJson(DB_FILE, currentData)
 #FUNCION PARA BORRAR ELEMENTOS DE LA BASE DE DATOS CON LOS VALORES QUE YO CONSIDERE
-def deleteJson(DB_FILE: str,path: List[str])->bool:
+def deleteJson(path: List[str])->bool:
     data = readJson(DB_FILE)
     if not data:
         return False
@@ -48,7 +48,7 @@ def deleteJson(DB_FILE: str,path: List[str])->bool:
         return True
     return False
 #ME INICIALIZA LA BASE DE DATOS, MAS PARA VALIDACIONES
-def initializeJson(DB_FILE: str, initialStructure:Dict)->None:
+def initializeJson(initialStructure:Dict)->None:
     if not os.path.isfile(DB_FILE):
         writeJson(DB_FILE, initialStructure)
     else:


### PR DESCRIPTION
![imagen_2025-03-07_150258863](https://github.com/user-attachments/assets/50c00333-5a5a-4c6f-8627-12db7b6b1e4f)
![Screenshot 2025-03-07 150214](https://github.com/user-attachments/assets/ac66283a-6a4d-48ac-aeda-92aa9cad83c3)
Mejora de la ruta DB_FILE para no crearlo en todos los modulos y simplemente importarlo